### PR TITLE
Patch auditwheel 3.2.0

### DIFF
--- a/manylinux1/docker/build_scripts/auditwheel.patch
+++ b/manylinux1/docker/build_scripts/auditwheel.patch
@@ -1,54 +1,17 @@
 diff --git a/repair.py b/repair.py
-index 64c9939..64a0809 100644
+index b37ecef..9cc0652 100644
 --- a/repair.py
 +++ b/repair.py
-@@ -10,6 +10,8 @@ from distutils.spawn import find_executable
- from typing import Dict, Optional
- import logging
+@@ -129,6 +129,12 @@ def copylib(src_path, dest_dir, patcher):
  
-+from wheel.install import WHEEL_INFO_RE  # type: ignore
-+
- from .policy import get_replace_platforms
- from .wheeltools import InWheelCtx, add_platforms
- from .wheel_abi import get_wheel_elfdata
-@@ -59,24 +61,14 @@ def repair_wheel(wheel_path: str, abi: str, lib_sdir: str, out_dir: str,
-     with InWheelCtx(wheel_path) as ctx:
-         ctx.out_wheel = pjoin(out_dir, wheel_fname)
- 
-+        dest_dir = WHEEL_INFO_RE(wheel_fname).group('name') + lib_sdir
-+
-+        if not exists(dest_dir):
-+            os.mkdir(dest_dir)
-+
-         # here, fn is a path to a python extension library in
-         # the wheel, and v['libs'] contains its required libs
-         for fn, v in external_refs_by_fn.items():
--            # pkg_root should resolve to like numpy/ or scipy/
--            # note that it's possible for the wheel to contain
--            # more than one pkg, which is why we detect the pkg root
--            # for each fn.
--            pkg_root = fn.split(os.sep)[0]
--
--            if pkg_root == fn:
--                # this file is an extension that's not contained in a
--                # directory -- just supposed to be directly in site-packages
--                dest_dir = lib_sdir + pkg_root.split('.')[0]
--            else:
--                dest_dir = pjoin(pkg_root, lib_sdir)
--
--            if not exists(dest_dir):
--                os.mkdir(dest_dir)
- 
-             ext_libs = v[abi]['libs']  # type: Dict[str, str]
-             for soname, src_path in ext_libs.items():
-@@ -143,9 +135,7 @@ def copylib(src_path, dest_dir):
- 
-     verify_patchelf()
-     check_call(['patchelf', '--set-soname', new_soname, dest_path])
--
--    if any(itertools.chain(rpaths['rpaths'], rpaths['runpaths'])):
--        patchelf_set_rpath(dest_path, dest_dir)
-+    check_call(['patchelf', '--force-rpath', '--set-rpath', '$ORIGIN', dest_path])
+     if any(itertools.chain(rpaths['rpaths'], rpaths['runpaths'])):
+         patcher.set_rpath(dest_path, dest_dir)
++   
++    old_rpaths = patcher.get_rpath(dest_path).split(':') 
++    if '$ORIGIN' not in old_rpaths:
++        rpath_set = OrderedDict([(old_rpath, '') for old_rpath in old_rpaths])
++        rpath_set['$ORIGIN'] = ''
++        patcher.set_rpath(dest_path, ':'.join(rpath_set).strip(':'))
  
      return new_soname, dest_path
  


### PR DESCRIPTION
This is the version of auditwheel included in the manylinux1 image
at the time of this commit. This patch is even more minimal than
previous patches, so should apply for much longer. What this patch
does is enforce that `$ORIGIN` is appended to all RPATHs for `.so` files
in the `<libname>.libs` directory (e.g. `htcondor.libs`) that is
created by auditwheel to hold all of the external libraries.